### PR TITLE
avoid reading files into program memory

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,11 +143,7 @@ func (basics BucketBasics) DownloadFile(bucketName string, objectKey string, fil
 		return err
 	}
 	defer file.Close()
-	body, err := io.ReadAll(result.Body)
-	if err != nil {
-		log.Printf("Couldn't read object body from %v. -> %v\n", objectKey, err)
-	}
-	_, err = file.Write(body)
+	_, err = io.Copy(file, result.Body)
 	return err
 }
 


### PR DESCRIPTION
Yo! Cool stuff my friend :)

I think this should be a small but helpful change. The current implementation reads the whole file into the program memory when it stores it in the `body` variable. Instead, it can be written to a file directly with `io.Copy`, avoiding an (perhaps large) allocation. This also makes the program friendly for large files since they could crash the program by making it run out of memory!

I'd encourage not trusting me blindly and testing it 😉